### PR TITLE
Fix(VocagularyListView)

### DIFF
--- a/GGomVoca/GGomVoca/View/VocabularyListView/Cell/VocabularyCell.swift
+++ b/GGomVoca/GGomVoca/View/VocabularyListView/Cell/VocabularyCell.swift
@@ -23,45 +23,7 @@ struct VocabularyCell: View {
     @State private var editVocabularyName: Bool = false
     
     var body: some View {
-        NavigationLink {
-            switch vocabulary.nationality! {
-            case "KO" :
-                KOWordListView(vocabularyID: vocabulary.id)
-                    .toolbar(.hidden, for: .tabBar)
-                    .onAppear {
-                        vm.manageRecentVocabulary(voca: vocabulary)
-                    }
-                
-            case "EN" :
-                ENWordListView(vocabularyID: vocabulary.id)
-                    .toolbar(.hidden, for: .tabBar)
-                    .onAppear {
-                        vm.manageRecentVocabulary(voca: vocabulary)
-                    }
-                
-            case "JA" :
-                JPWordListView(vocabularyID: vocabulary.id)
-                    .toolbar(.hidden, for: .tabBar)
-                    .onAppear {
-                        vm.manageRecentVocabulary(voca: vocabulary)
-                    }
-                
-            case "FR" :
-                FRWordListView(vocabularyID: vocabulary.id)
-                    .toolbar(.hidden, for: .tabBar)
-                    .onAppear {
-                        vm.manageRecentVocabulary(voca: vocabulary)
-                    }
-            default:
-                WordListView(vocabularyID: vocabulary.id)
-                    .toolbar(.hidden, for: .tabBar)
-                    .onAppear {
-                        vm.manageRecentVocabulary(voca: vocabulary)
-                    }
-            }
-        } label: {
-            Text(vocabulary.name ?? "")
-        }
+        NavigationLink(vocabulary.name ?? "", value: vocabulary)
         //단어장 즐겨찾기 추가 스와이프
         .swipeActions(edge: .leading) {
             Button {
@@ -99,7 +61,6 @@ struct VocabularyCell: View {
             favoriteCompletion()
         } content: {
             EditVocabularyView(vocabulary: vocabulary)
-            
         }
         // MARK: iPhone에서 단어장을 삭제할 때 띄울 메세지
         .actionSheet(isPresented: $deleteActionSheet) {
@@ -119,7 +80,7 @@ struct VocabularyCell: View {
             }), secondaryButton: .cancel(Text("취소")))
         }
         // !!!: 추후 confirmationDialog가 안정화 되면 actionSheet대신 적용
-//        .confirmationDialog("단어장 삭제", isPresented: $isDeleteVocabulary) {
+//        .confirmationDialog("단어장 삭제", isPresented: $deleteAlert) {
 //            Button("단어장 삭제", role: .destructive) {
 //                vm.updateDeletedData(id: vocabulary.id!)
 //                deleteCompletion()

--- a/GGomVoca/GGomVoca/View/VocabularyListView/Cell/VocabularyCellViewModel.swift
+++ b/GGomVoca/GGomVoca/View/VocabularyListView/Cell/VocabularyCellViewModel.swift
@@ -13,7 +13,6 @@ class VocabularyCellViewModel{
      단어장 삭제 후 반영 함수
      */
     func updateDeletedData(id: UUID) {
-
         let managedContext = viewContext
         let vocabularyFetch = Vocabulary.fetchRequest()
         vocabularyFetch.predicate = NSPredicate(format: "id = %@", id as CVarArg)
@@ -24,7 +23,7 @@ class VocabularyCellViewModel{
             let objectUpdate = results[0] // as! NSManagedObject
             objectUpdate.setValue("\(Date())", forKey: "deleatedAt")
             
-            //
+            /// - 단어장 삭제 시 최근 본 단어장에서도 삭제
             deleteRecentVoca(id: "\(id)")
             
             try self.viewContext.save()
@@ -39,36 +38,16 @@ class VocabularyCellViewModel{
         }
     }
     
-    /*
-      최근 본 단어장 (UserDefault) 삭제
-     */
-    func deleteRecentVoca(id : String){
-        var before =  UserManager.shared.recentVocabulary // [voca1, voca2]
+    // MARK: 최근 본 단어장을 UserDefault에서 삭제
+    func deleteRecentVoca(id : String) {
+        // [voca1, voca2]
+        var before =  UserManager.shared.recentVocabulary
         if let idx = before.firstIndex(of: "\(id)"){
             before.remove(at: idx)
         }
         UserManager.shared.recentVocabulary = before
     }
-    
-    // 3개 가져오고 지우기 (관리)
-    func manageRecentVocabulary(voca: Vocabulary) {
         
-        //중복되는 최근 단어장 제거
-        deleteRecentVoca(id: "\(voca.id!)")
-        var before =  UserManager.shared.recentVocabulary // [voca1, voca2]
-        
-        before.insert("\(voca.id!)", at: 0)
-        
-        if before.count >= 4{
-            before.removeLast()
-        }
-
-        UserManager.shared.recentVocabulary = before
-        
-        print( "manageRecentVocabulary() :\(UserManager.shared.recentVocabulary)")
-        
-    }
-    
     func saveContext() {
         do {
             print("saveContext")

--- a/GGomVoca/GGomVoca/View/VocabularyListView/ViewModel/VocabularyListViewModel.swift
+++ b/GGomVoca/GGomVoca/View/VocabularyListView/ViewModel/VocabularyListViewModel.swift
@@ -11,61 +11,41 @@ import SwiftUI
 
 //Server -> Repository(reposiroty pattern) -> ViewModel
 class VocabularyListViewModel : ObservableObject {
+    // MARK: Store Property
+    var repository : CoredataRepository = CoredataRepository()
     
-    var repository : CoredataRepository = CoredataRepository() //Store
-    //@Environment(\.managedObjectContext) private var viewContext -> Environment 래퍼 프로퍼티 정의 다시 공부하기(여기서 사용하면 안 됨)
-    @Published var vocabularyList : [Vocabulary]  = []
-    @Published  var recentVocabularyList : [Vocabulary]  = []
-    //즐겨찾기
-    @Published var favoriteVoca : [Vocabulary] = []
-    //한국어
-    @Published var koreanVoca : [Vocabulary] = []
-    //일본어
-    @Published var japaneseVoca : [Vocabulary] = []
-    //영어
-    @Published var englishVoca : [Vocabulary] = []
-    //중국어
-    @Published var chineseVoca : [Vocabulary] = []
-    //프랑스어
-    var frenchVoca : [Vocabulary] = []
-    //독일어
-    var germanVoca : [Vocabulary] = []
-    //스페인어
-    var spanishVoca : [Vocabulary] = []
-    //이탈리아어
-    var italianVoca : [Vocabulary] = []
+    // MARK: Published Properties
+    @Published var vocabularyList       : [Vocabulary] = [] // all vocabularies
+    @Published var recentVocabularyList : [Vocabulary] = [] // 최근 본 단어장
+    @Published var favoriteVoca         : [Vocabulary] = [] // 즐겨찾기
+    @Published var koreanVoca           : [Vocabulary] = [] // 한국어 단어장
+    @Published var englishVoca          : [Vocabulary] = [] // 영어 단어장
+    @Published var japaneseVoca         : [Vocabulary] = [] // 일본어 단어장
+    @Published var frenchVoca           : [Vocabulary] = [] // 프랑스어 단어장
     
     init(vocabularyList: [Vocabulary]) {
         self.vocabularyList = vocabularyList
     }
     
+    // MARK: Clear Vocabulary Lists
     func clearVoca() {
         vocabularyList = []
-//        recentVocabularyList = []
         favoriteVoca = []
         koreanVoca = []
         japaneseVoca = []
         englishVoca = []
-        chineseVoca = []
         frenchVoca = []
-        germanVoca = []
-        spanishVoca = []
-        italianVoca = []
     }
-    
-    /*
-     Get Vocabulary List
-     */
+
+    // MARK: Get Vocabulary Lists
     func getVocabularyData() {
-        
         var results = repository.getVocabularyData()
         clearVoca()
+        
         for voca in results {
             if voca.deleatedAt == nil {
-                print("name : \(voca.name!)")
-                print("isFavorite : \(voca.isFavorite)")
-                print("nationality : \(voca.nationality!)")
                 vocabularyList.append(voca)
+                
                 if voca.isFavorite {
                     favoriteVoca.append(voca)
                 }
@@ -76,13 +56,13 @@ class VocabularyListViewModel : ObservableObject {
                     continue
                 }
                 
-                if voca.nationality == "JA" {
-                    japaneseVoca.append(voca)
+                if voca.nationality == "EN" {
+                    englishVoca.append(voca)
                     continue
                 }
                 
-                if voca.nationality == "EN" {
-                    englishVoca.append(voca)
+                if voca.nationality == "JA" {
+                    japaneseVoca.append(voca)
                     continue
                 }
                 
@@ -90,67 +70,32 @@ class VocabularyListViewModel : ObservableObject {
                     frenchVoca.append(voca)
                     continue
                 }
-                
-                if voca.nationality == "CH" {
-                    chineseVoca.append(voca)
-                    continue
-                }
-                
-                if voca.nationality == "DE" {
-                    germanVoca.append(voca)
-                    continue
-                }
-                
-                if voca.nationality == "ES" {
-                    spanishVoca.append(voca)
-                    continue
-                }
-                
-                if voca.nationality == "IT" {
-                    italianVoca.append(voca)
-                    continue
-                }
             }
         }
-        
-        
-//        self.vocabularyList = results.filter{
-//            $0.deleatedAt == nil || $0.deleatedAt?.count == 0
-//        }
-//        
-//        favoriteVoca = vocabularyList.filter {
-//            $0.isFavorite == true && $0.deleatedAt == nil
-//        }
-//        koreanVoca = results.filter {
-//            $0.nationality == "KO" && $0.deleatedAt == nil
-//        }
-//        japaneseVoca = results.filter {
-//            $0.nationality == "JA" && $0.deleatedAt == nil
-//        }
-//        englishVoca = results.filter {
-//            $0.nationality == "EN" && $0.deleatedAt == nil
-//        }
-//        chineseVoca = results.filter {
-//            $0.nationality == "CH" && $0.deleatedAt == nil
-//        }
-//        frenchVoca = results.filter {
-//            $0.nationality == "FR" && $0.deleatedAt == nil
-//        }
-//        germanVoca = results.filter {
-//            $0.nationality == "DE" && $0.deleatedAt == nil
-//        }
-//        spanishVoca = results.filter {
-//            $0.nationality == "ES" && $0.deleatedAt == nil
-//        }
-//        italianVoca = results.filter {
-//            $0.nationality == "IT" && $0.deleatedAt == nil
-//        }
-        
-        
-        
-//        return results
     }
     
+    // MARK: 최근 본 단어장을 UserDefault에서 삭제
+    func deleteRecentVoca(id : String) {
+        // [voca1, voca2]
+        var before =  UserManager.shared.recentVocabulary
+        if let idx = before.firstIndex(of: "\(id)"){
+            before.remove(at: idx)
+        }
+        UserManager.shared.recentVocabulary = before
+    }
     
-    
+    // MARK: 최근 본 단어장 관리 메서드
+    func manageRecentVocabulary(voca: Vocabulary) {
+        /// - 기존에 최근 본 단어장에 들어있는 단어장을 또 확인 한 경우 배열에서 지우고 배열의 첫번째 요소로 다시 삽입
+        deleteRecentVoca(id: "\(voca.id!)")
+        var before =  UserManager.shared.recentVocabulary
+        
+        before.insert("\(voca.id!)", at: 0)
+        
+        if before.count >= 4{
+            before.removeLast()
+        }
+
+        UserManager.shared.recentVocabulary = before
+    }
 }


### PR DESCRIPTION
## 개요
- #73 

## 작업사항
### VocabularyListView
- Rollback NavigationView to NavigationSplitView
- NavigationSplitView
  - sidebar에서 NavigationLink(destination: , label: ) → NavigationLink(title: , value: )로 수정
  - detail에서 언어에 맞게 WordListView를 호출하고 id 수정자를 적용함(같은 section 안에서 빠르게 전환하더라도 detail이 바뀌지 않는 버그 Fix)
- 지원하지 않는 언어에 대한 코드 삭제
- 주석 수정

### VocabularyCell
- NavigationLink(title: , value: )로 수정
- confirmationDialog가 잘 작동하는지 확인했으나 여전히 오류가 있음을 확인함

### ViewModel
- WordListView를 VocabularyListView에서 호출하게 됨에 따라 최근 본 단어장에 대한 viewModel 메서드를 이동

