### PR TITLE
Fix/99 Pinned Vocabulary

### DIFF
--- a/GGomVoca/GGomVoca/View/VocabularyListView/ViewModel/VocabularyListViewModel.swift
+++ b/GGomVoca/GGomVoca/View/VocabularyListView/ViewModel/VocabularyListViewModel.swift
@@ -17,7 +17,7 @@ class VocabularyListViewModel : ObservableObject {
     // MARK: Published Properties
     @Published var vocabularyList       : [Vocabulary] = [] // all vocabularies
     @Published var recentVocabularyList : [Vocabulary] = [] // 최근 본 단어장
-    @Published var favoriteVoca         : [Vocabulary] = [] // 즐겨찾기
+    @Published var pinnedVocabularyList : [Vocabulary] = [] // 즐겨찾기
     @Published var koreanVoca           : [Vocabulary] = [] // 한국어 단어장
     @Published var englishVoca          : [Vocabulary] = [] // 영어 단어장
     @Published var japaneseVoca         : [Vocabulary] = [] // 일본어 단어장
@@ -30,7 +30,7 @@ class VocabularyListViewModel : ObservableObject {
     // MARK: Clear Vocabulary Lists
     func clearVoca() {
         vocabularyList = []
-        favoriteVoca = []
+        pinnedVocabularyList = []
         koreanVoca = []
         japaneseVoca = []
         englishVoca = []
@@ -47,7 +47,7 @@ class VocabularyListViewModel : ObservableObject {
                 vocabularyList.append(voca)
                 
                 if voca.isPinned {
-                    favoriteVoca.append(voca)
+                    pinnedVocabularyList.append(voca)
                     continue
                 }
                 

--- a/GGomVoca/GGomVoca/View/VocabularyListView/VocabularyListView.swift
+++ b/GGomVoca/GGomVoca/View/VocabularyListView/VocabularyListView.swift
@@ -86,9 +86,9 @@ struct VocabularyListView: View {
     func initVocaListView() -> some View {
         List(selection: $selectedVocabulary) {
             // MARK: 고정된 단어장;
-            if !viewModel.favoriteVoca.isEmpty {
+            if !viewModel.pinnedVocabularyList.isEmpty {
                 Section("고정된 단어장") {
-                    ForEach(viewModel.favoriteVoca) { vocabulary in
+                    ForEach(viewModel.pinnedVocabularyList) { vocabulary in
                         VocabularyCell(
                             favoriteCompletion: {
                                 viewModel.getVocabularyData()
@@ -313,7 +313,7 @@ struct VocabularyListView: View {
         case "recent":
             viewModel.recentVocabularyList.move(fromOffsets: source, toOffset: destination)
         case "favorite":
-            viewModel.favoriteVoca.move(fromOffsets: source, toOffset: destination)
+            viewModel.pinnedVocabularyList.move(fromOffsets: source, toOffset: destination)
         default:
             break
         }
@@ -332,7 +332,7 @@ struct VocabularyListView: View {
         case "recent":
             viewModel.recentVocabularyList.remove(atOffsets: offsets)
         case "favorite":
-            viewModel.favoriteVoca.remove(atOffsets: offsets)
+            viewModel.pinnedVocabularyList.remove(atOffsets: offsets)
         default:
             break
         }


### PR DESCRIPTION
## 개요
- #99 

## 작업사항
- 고정된 단어장은 언어별 Section에서 나오지 않도록 수정
- List에서 id값이 같아 활성화되는 버튼이 다른 버그 수정을 위함

## 변경로직
- VocabularyViewModel에서 전체 단어장을 불러오고 분류하는 과정에서 isPinned == true인 경우 pinnedVocabularyList 배열에 추가되고 중복 분류 되지 않도록 변경