### PR TITLE
Fix(Coredata): recentTestResults 타입 변경([Bool] -> [String])으로 인한 Word Extension 코드를 수정한다.

### DIFF
--- a/GGomVoca/GGomVoca/Extension/Word+CKRecord.swift
+++ b/GGomVoca/GGomVoca/Extension/Word+CKRecord.swift
@@ -21,7 +21,7 @@ extension Word{
               let isMemorized = ckRecord["isMemorized"] as? Bool,
               let meaning = ckRecord["meaning"] as? [String],
               let option = ckRecord["option"] as? String,
-              let recentTestResults = ckRecord["recentTestResults"] as? [Bool],
+              let recentTestResults = ckRecord["recentTestResults"] as? [String],
               let createdAt = ckRecord["createdAt"] as? String,
               let vocabularyIDStr = ckRecord["vocabularyID"] as? String,
               let vocabularyID = UUID(uuidString: vocabularyIDStr),

--- a/GGomVoca/GGomVoca/Service/WordList/WordService.swift
+++ b/GGomVoca/GGomVoca/Service/WordList/WordService.swift
@@ -12,9 +12,9 @@ protocol WordService{
     //MARK: 데이터를 디스크에 저장
     func saveContext()
    //MARK: 단어장 리스트 불러오기
-    func fetchVocabularyList() -> AnyPublisher<[Vocabulary], FirstPartyRepoError>
+    func fetchWordList() -> AnyPublisher<[Word], FirstPartyRepoError>
     //MARK: 단어장 추가하기
-    func postVocaData(vocaName : String, nationality: String) -> AnyPublisher<Vocabulary, FirstPartyRepoError>
+    func postWordData(vocaName : String, nationality: String) -> AnyPublisher<Vocabulary, FirstPartyRepoError>
     //MARK: 단어장 고정 상태 업데이트
     //TODO: Publisher 반환타입 수정
     func updatePinnedVoca(id: UUID) -> AnyPublisher<String, FirstPartyRepoError>


### PR DESCRIPTION
## 개요
Fix(Coredata): recentTestResults 타입 변경([Bool] -> [String])으로 인한 Word Extension 코드를 수정한다.
## 작업사항
 CoreData Word Type <-> CloudKit Word Type Mapping 코드 타입 수정

## 변경로직

close : #131